### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 FROM php:7.3-apache 
-RUN docker-php-ext-install mysqli
+RUN docker-php-ext-install mysqli pdo_mysql
 RUN apt-get update \
     && apt-get install -y libzip-dev \
     && apt-get install -y zlib1g-dev \


### PR DESCRIPTION
added pdo_mysql into Dockerfile, since PDO is pretty mainstream as db driver.
